### PR TITLE
Add download files from Dropbox python script

### DIFF
--- a/dropbox_to_local.py
+++ b/dropbox_to_local.py
@@ -1,22 +1,22 @@
 import dropbox
 import os
 
-dbx = dropbox.Dropbox('OAUTH_API_CREDENTIALS_HERE')
-dbx.users_get_current_account()
+DROPBOX = dropbox.Dropbox('OAUTH_API_CREDENTIALS_HERE')
+DROPBOX.users_get_current_account()
 
-lp = "/local/directory/path" # local directory path
-r = "/folder_name" # directory in dropbox to download
+LOCAL_DIRECTORY_PATH = "/local/directory/path" # local directory path
+ROOT = "/folder_name" # directory in dropbox to download
 
 def download_files(local_path, root):
-	for entry in dbx.files_list_folder(root).entries:
-		if entry.__class__ == dropbox.files.FolderMetadata:
+	for entry in DROPBOX.files_list_folder(root).entries:
+		if isinstance(entry, dropbox.files.FolderMetadata):
 			# print(entry.name, "folder", entry.path_display) # for debugging
 			root = root + entry.path_display
 			if not os.path.exists(local_path + entry.path_display):
 				os.makedirs(local_path + entry.path_display)
 			download_files(local_path, entry.path_display)
-		elif entry.__class__ == dropbox.files.FileMetadata:
+		elif isinstance(entry, dropbox.files.FileMetadata):
 			# print(entry.name, "file", local_path + entry.path_display, entry.path_display) # for debugging
-			dbx.files_download_to_file((local_path + entry.path_display), entry.path_display)
+			DROPBOX.files_download_to_file((local_path + entry.path_display), entry.path_display)
 
-download_files(lp, r)
+download_files(LOCAL_DIRECTORY_PATH, ROOT)

--- a/dropbox_to_local.py
+++ b/dropbox_to_local.py
@@ -1,0 +1,22 @@
+import dropbox
+import os
+
+dbx = dropbox.Dropbox('OAUTH_API_CREDENTIALS_HERE')
+dbx.users_get_current_account()
+
+lp = "/local/directory/path" # local directory path
+r = "/folder_name" # directory in dropbox to download
+
+def download_files(local_path, root):
+	for entry in dbx.files_list_folder(root).entries:
+		if entry.__class__ == dropbox.files.FolderMetadata:
+			# print(entry.name, "folder", entry.path_display) # for debugging
+			root = root + entry.path_display
+			if not os.path.exists(local_path + entry.path_display):
+				os.makedirs(local_path + entry.path_display)
+			download_files(local_path, entry.path_display)
+		elif entry.__class__ == dropbox.files.FileMetadata:
+			# print(entry.name, "file", local_path + entry.path_display, entry.path_display) # for debugging
+			dbx.files_download_to_file((local_path + entry.path_display), entry.path_display)
+
+download_files(lp, r)


### PR DESCRIPTION
1. overwrite `OAUTH_API_CREDENTIALS_HERE` in [this line](https://github.com/uwblueprint/poly/blob/d63109362ccebed9e1bb66cd086256665abba74b/dropbox_to_local.py#L4) with the OAuth access token from dropbox (can be created [here](https://www.dropbox.com/developers/apps/))
2. overwrite `"/local/directory/path"` in [this line](https://github.com/uwblueprint/poly/blob/d63109362ccebed9e1bb66cd086256665abba74b/dropbox_to_local.py#L7) with the local directory path (the downloaded files will be saved here)
3. overwrite `"/folder_name"` in [this line](https://github.com/uwblueprint/poly/blob/d63109362ccebed9e1bb66cd086256665abba74b/dropbox_to_local.py#L8) with the dropbox directory path (path where the files are stored in dropbox)